### PR TITLE
Add CLI scaffold and related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# CLI build output
+cli/mantis
+cli/mantis.exe
+
+# Generated test projects (when running from cli/)
+cli/testapp/
+context.md

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,0 +1,3 @@
+module mantis
+
+go 1.22

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+const mantisVersion = "0.1.0"
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	subcmd := os.Args[1]
+	if subcmd != "new" {
+		printUsage()
+		os.Exit(1)
+	}
+
+	var projectName string
+	var templatePath string
+
+	args := os.Args[2:]
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--template-path" {
+			if i+1 >= len(args) {
+				fmt.Fprintf(os.Stderr, "mantis: --template-path requires a path\n")
+				os.Exit(1)
+			}
+			templatePath = args[i+1]
+			i++
+		} else if projectName == "" {
+			projectName = args[i]
+		}
+	}
+
+	if projectName == "" {
+		fmt.Fprintf(os.Stderr, "mantis: project name required\n")
+		printUsage()
+		os.Exit(1)
+	}
+
+	if err := validateProjectName(projectName); err != nil {
+		fmt.Fprintf(os.Stderr, "mantis: %v\n", err)
+		os.Exit(1)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mantis: %v\n", err)
+		os.Exit(1)
+	}
+
+	targetDir := filepath.Join(cwd, projectName)
+	if _, err := os.Stat(targetDir); err == nil {
+		fmt.Fprintf(os.Stderr, "mantis: directory %q already exists\n", projectName)
+		os.Exit(1)
+	}
+
+	resolvedTemplate, err := resolveTemplateFromGitHub(templatePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mantis: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := CopyDir(resolvedTemplate, targetDir); err != nil {
+		fmt.Fprintf(os.Stderr, "mantis: copy failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("  Copying template...     done")
+
+	if err := ReplaceInFiles(targetDir, "__project_name__", projectName); err != nil {
+		fmt.Fprintf(os.Stderr, "mantis: replace failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("  Replacing placeholders... done")
+
+	if err := Finalize(targetDir, projectName); err != nil {
+		fmt.Fprintf(os.Stderr, "mantis: finalize failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("  Initializing git...     done")
+	fmt.Println()
+	fmt.Printf("  cd %s && nix develop\n", projectName)
+}
+
+func printUsage() {
+	fmt.Fprintf(os.Stderr, "usage: mantis new <project-name> [--template-path <path>]\n")
+}
+
+var projectNameRe = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*$`)
+
+func validateProjectName(name string) error {
+	if len(name) == 0 {
+		return fmt.Errorf("project name cannot be empty")
+	}
+	if len(name) > 64 {
+		return fmt.Errorf("project name too long")
+	}
+	if !projectNameRe.MatchString(name) {
+		return fmt.Errorf("project name must start with a letter and contain only letters, digits, hyphens, and underscores")
+	}
+	return nil
+}
+
+func validateTemplateDir(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", dir)
+	}
+	backend := filepath.Join(dir, "backend")
+	frontend := filepath.Join(dir, "frontend")
+	if _, err := os.Stat(backend); err != nil {
+		return fmt.Errorf("template must contain backend/: %w", err)
+	}
+	if _, err := os.Stat(frontend); err != nil {
+		return fmt.Errorf("template must contain frontend/: %w", err)
+	}
+	return nil
+}

--- a/cli/readme.md
+++ b/cli/readme.md
@@ -3,7 +3,16 @@ the scaffold tool. written in go.
 builds a mantis project from the template directory.
 copies files, substitutes project name, prints next steps.
 
-go run main.go new my-project
+	go run . new my-project
+	mantis new my-project
 
-no external dependencies. no magic.
-if something is wrong, read the source.
+Template source (in order):
+  1. --template-path <path>  (local override)
+  2. ~/.mantis/cache/       (cached from GitHub)
+  3. GitHub latest release  (alvinliju/mantis)
+
+Env vars:
+  MANTIS_TEMPLATE_REPO  owner/repo  (default: alvinliju/mantis)
+  MANTIS_GITHUB_TOKEN   token       (optional, for higher rate limits)
+
+Requires a GitHub release on the template repo. Create one first.

--- a/cli/scaffold.go
+++ b/cli/scaffold.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+var (
+	skipDirs = map[string]bool{
+		"node_modules": true,
+		".next":        true,
+		"__pycache__":  true,
+		".git":         true,
+	}
+	skipFiles = map[string]bool{
+		"package-lock.json": true,
+	}
+	binaryExts = map[string]bool{
+		".svg": true, ".png": true, ".jpg": true, ".jpeg": true,
+		".ico": true, ".woff": true, ".woff2": true, ".ttf": true, ".eot": true,
+	}
+)
+
+func CopyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		if rel == "." {
+			if err := os.MkdirAll(dst, 0755); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		if d.IsDir() {
+			if skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			target := filepath.Join(dst, rel)
+			return os.MkdirAll(target, 0755)
+		}
+
+		if skipFiles[d.Name()] {
+			return nil
+		}
+
+		target := filepath.Join(dst, rel)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+			return err
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, info.Mode())
+	})
+}
+
+func ReplaceInFiles(dir, placeholder, replacement string) error {
+	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		ext := strings.ToLower(filepath.Ext(d.Name()))
+		if binaryExts[ext] {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		if !bytes.Contains(data, []byte(placeholder)) {
+			return nil
+		}
+
+		newData := bytes.ReplaceAll(data, []byte(placeholder), []byte(replacement))
+		return os.WriteFile(path, newData, 0644)
+	})
+}
+
+func Finalize(dir, projectName string) error {
+	tomlContent := fmt.Sprintf(`[project]
+name = %q
+mantis_version = %q
+created_at = %q
+`, projectName, mantisVersion, time.Now().UTC().Format(time.RFC3339))
+
+	tomlPath := filepath.Join(dir, "mantis.toml")
+	if err := os.WriteFile(tomlPath, []byte(tomlContent), 0644); err != nil {
+		return fmt.Errorf("write mantis.toml: %w", err)
+	}
+
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git init: %w", err)
+	}
+
+	return nil
+}

--- a/cli/template_source.go
+++ b/cli/template_source.go
@@ -1,0 +1,289 @@
+package main
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	githubAPIBase     = "https://api.github.com"
+	defaultRepoOwner  = "alvinliju"
+	defaultRepoName   = "mantis"
+	cacheMetadataFile = "metadata.json"
+	templateSubdir    = "template"
+)
+
+type releaseResponse struct {
+	TagName    string `json:"tag_name"`
+	ZipballURL string `json:"zipball_url"`
+}
+
+type cacheMetadata struct {
+	Tag        string `json:"tag"`
+	ResolvedAt string `json:"resolved_at"`
+	TemplatePath string `json:"template_path"`
+}
+
+func cacheDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	cache := filepath.Join(home, ".mantis", "cache")
+	if err := os.MkdirAll(cache, 0755); err != nil {
+		return "", fmt.Errorf("cannot create cache directory: %w", err)
+	}
+	return cache, nil
+}
+
+func resolveTemplateFromGitHub(flagPath string) (string, error) {
+	if flagPath != "" {
+		abs, err := filepath.Abs(flagPath)
+		if err != nil {
+			return "", fmt.Errorf("invalid --template-path: %w", err)
+		}
+		if err := validateTemplateDir(abs); err != nil {
+			return "", err
+		}
+		return abs, nil
+	}
+
+	owner := defaultRepoOwner
+	repo := defaultRepoName
+	if v := os.Getenv("MANTIS_TEMPLATE_REPO"); v != "" {
+		parts := strings.SplitN(v, "/", 2)
+		if len(parts) == 2 {
+			owner, repo = parts[0], parts[1]
+		}
+	}
+
+	cacheRoot, err := cacheDir()
+	if err != nil {
+		return "", err
+	}
+
+	metaPath := filepath.Join(cacheRoot, cacheMetadataFile)
+
+	if meta, err := os.ReadFile(metaPath); err == nil {
+		var m cacheMetadata
+		if json.Unmarshal(meta, &m) == nil && m.TemplatePath != "" {
+			if _, err := os.Stat(m.TemplatePath); err == nil {
+				tag, _, err := fetchLatestRelease(owner, repo)
+				if err != nil {
+					return m.TemplatePath, nil
+				}
+				if tag == m.Tag {
+					return m.TemplatePath, nil
+				}
+			}
+		}
+	}
+
+	fmt.Println("  Resolving template (github)...")
+	tag, zipURL, err := fetchLatestRelease(owner, repo)
+	if err != nil {
+		return "", err
+	}
+	fmt.Printf("  Downloading template %s...\n", tag)
+
+	zipPath, err := downloadZip(zipURL, cacheRoot)
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(zipPath)
+
+	extractRoot := filepath.Join(cacheRoot, "extract-"+tag)
+	if err := os.MkdirAll(extractRoot, 0755); err != nil {
+		return "", fmt.Errorf("cannot create extract directory: %w", err)
+	}
+
+	templatePath, err := extractZipSafely(zipPath, extractRoot)
+	if err != nil {
+		os.RemoveAll(extractRoot)
+		return "", err
+	}
+
+	if err := validateTemplateDir(templatePath); err != nil {
+		os.RemoveAll(extractRoot)
+		return "", err
+	}
+
+	oldLatest := filepath.Join(cacheRoot, "latest")
+	os.RemoveAll(oldLatest)
+	latestPath := filepath.Join(cacheRoot, "latest")
+	if err := os.Rename(extractRoot, latestPath); err != nil {
+		os.RemoveAll(extractRoot)
+		return "", fmt.Errorf("cannot update cache: %w", err)
+	}
+	rel, _ := filepath.Rel(extractRoot, templatePath)
+	templatePath = filepath.Join(latestPath, rel)
+
+	meta := cacheMetadata{
+		Tag:         tag,
+		ResolvedAt:  time.Now().UTC().Format(time.RFC3339),
+		TemplatePath: templatePath,
+	}
+	metaJSON, _ := json.MarshalIndent(meta, "", "  ")
+	os.WriteFile(metaPath, metaJSON, 0644)
+
+	return templatePath, nil
+}
+
+func fetchLatestRelease(owner, repo string) (tag, zipURL string, err error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/releases/latest", githubAPIBase, owner, repo)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "mantis-cli/1.0")
+	if tok := os.Getenv("MANTIS_GITHUB_TOKEN"); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("network error fetching release: %w (check connectivity)", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return "", "", fmt.Errorf("no releases found for %s/%s (create a release first)", owner, repo)
+	}
+	if resp.StatusCode == 403 {
+		return "", "", fmt.Errorf("GitHub API rate limit exceeded (set MANTIS_GITHUB_TOKEN for higher limits)")
+	}
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return "", "", fmt.Errorf("GitHub API error %d: %s", resp.StatusCode, string(body))
+	}
+
+	var r releaseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return "", "", fmt.Errorf("invalid GitHub response: %w", err)
+	}
+	if r.ZipballURL == "" {
+		return "", "", fmt.Errorf("release has no zipball_url")
+	}
+	return r.TagName, r.ZipballURL, nil
+}
+
+func downloadZip(url, cacheRoot string) (string, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "mantis-cli/1.0")
+	if tok := os.Getenv("MANTIS_GITHUB_TOKEN"); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("download failed: %w (check connectivity)", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("download failed with status %d", resp.StatusCode)
+	}
+
+	outPath := filepath.Join(cacheRoot, "source.zip")
+	out, err := os.Create(outPath)
+	if err != nil {
+		return "", fmt.Errorf("cannot write cache file: %w", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		os.Remove(outPath)
+		return "", fmt.Errorf("download failed: %w", err)
+	}
+	return outPath, nil
+}
+
+func extractZipSafely(zipPath, extractDir string) (templatePath string, err error) {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return "", fmt.Errorf("invalid zip archive: %w", err)
+	}
+	defer r.Close()
+
+	extractDir, err = filepath.Abs(extractDir)
+	if err != nil {
+		return "", err
+	}
+
+	var topLevel string
+	for _, f := range r.File {
+		clean := filepath.ToSlash(f.Name)
+		clean = strings.TrimSuffix(clean, "/")
+		if clean == "" {
+			continue
+		}
+		if strings.Contains(clean, "..") {
+			continue
+		}
+		target := filepath.Join(extractDir, filepath.FromSlash(clean))
+		rel, err := filepath.Rel(extractDir, target)
+		if err != nil || strings.HasPrefix(rel, "..") || filepath.IsAbs(rel) {
+			continue
+		}
+
+		parts := strings.Split(clean, "/")
+		if topLevel == "" && len(parts) > 0 {
+			topLevel = parts[0]
+		}
+
+		if f.FileInfo().IsDir() {
+			os.MkdirAll(target, 0755)
+			continue
+		}
+
+		dir := filepath.Dir(target)
+		os.MkdirAll(dir, 0755)
+
+		rc, err := f.Open()
+		if err != nil {
+			return "", fmt.Errorf("cannot read zip entry %s: %w", f.Name, err)
+		}
+		w, err := os.Create(target)
+		if err != nil {
+			rc.Close()
+			return "", err
+		}
+		_, err = io.Copy(w, rc)
+		w.Close()
+		rc.Close()
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if topLevel != "" {
+		templatePath = filepath.Join(extractDir, topLevel, templateSubdir)
+	} else {
+		templatePath = filepath.Join(extractDir, templateSubdir)
+	}
+
+	if _, err := os.Stat(templatePath); err != nil {
+		entries, _ := os.ReadDir(extractDir)
+		for _, e := range entries {
+			if e.IsDir() {
+				p := filepath.Join(extractDir, e.Name(), templateSubdir)
+				if _, err := os.Stat(p); err == nil {
+					return p, nil
+				}
+			}
+		}
+		return "", fmt.Errorf("zip does not contain template/ directory")
+	}
+	return templatePath, nil
+}


### PR DESCRIPTION
Added CLI which will unflod the templates dir, and skip the example files/folders
GitHub-backed template fetching so mantis new <app-name> works from any directory, without needing the mantis repo locally.

Usage:
`mantis new myapp`
Will fetch the latest release from github for the templates and unzip it by replacing the preview names.

Notes:
Default repo: alvinliju/mantis. Requires a published, non-prerelease GitHub release.
Cache stored under ~/.mantis/cache/ and refreshed when the latest release changes.
Uses standard library only (net/http, archive/zip, encoding/json).